### PR TITLE
Improve ru translations and error display

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -29,7 +29,7 @@ class ArticlesController < ApplicationController
     @article.user_id = current_user.id
 
     if @article.save
-      redirect_to articles_path(@article)
+      redirect_to articles_path(@article), notice: "Поручение создано!"
     else
       render action: :new
     end
@@ -37,7 +37,7 @@ class ArticlesController < ApplicationController
 
   def update
     if @article.update(article_params)
-      redirect_to @article, notice: "Article updated!"
+      redirect_to @article, notice: "Поручение обновлено!"
     else
       render :edit
     end
@@ -46,7 +46,7 @@ class ArticlesController < ApplicationController
   def destroy
     @article.comments.destroy_all
     @article.destroy # Удаляем статью вместе с комментариями
-    redirect_to articles_path, notice: "Article was successfully deleted."
+    redirect_to articles_path, notice: "Поручение удалено."
   end
 
   private
@@ -65,7 +65,7 @@ class ArticlesController < ApplicationController
 
     # Остальные действия доступны только автору
     if current_user != @article.user
-      redirect_to articles_path, alert: "You are not authorized to perform this action."
+      redirect_to articles_path, alert: "У вас нет прав для выполнения этого действия."
     end
   end
 end

--- a/app/views/articles/edit.html.erb
+++ b/app/views/articles/edit.html.erb
@@ -1,4 +1,5 @@
 <h1>Изменить поручение</h1>
+<%= render "devise/shared/error_messages", resource: @article %>
 <%=form_with model: @article, url:article_path(@article),method: :patch, local: true do |f|%>
 	
 	<%=f.label :title, "Заголовок"%>

--- a/app/views/articles/new.html.erb
+++ b/app/views/articles/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, "Новое поручение" %>
 <h1>Новое поручение</h1>
+<%= render "devise/shared/error_messages", resource: @article %>
 
 <div class="d-flex gap-2">
   <%= form_with model: @article, local: true, data: { turbo: false } do |f| %>

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -13,11 +13,21 @@ ru:
       invalid: "Неверный email или пароль."
       
   activerecord:
+    models:
+      article: "Поручение"
     attributes:
       article:
+        title: "Заголовок"
+        text: "Текст"
         status:
           in_progress: "В работе"
           completed: "Выполнено"
+
+  errors:
+    messages:
+      not_saved:
+        one: "%{count} ошибка не позволила сохранить %{resource}:"
+        other: "%{count} ошибок не позволили сохранить %{resource}:"
   
   contacts:
     contact_us: "Свяжитесь с нами"


### PR DESCRIPTION
## Summary
- show error messages on article forms
- translate flash messages to Russian
- localize ActiveRecord labels and error heading

## Testing
- `bundle exec rake test` *(fails: ruby 3.3.6 not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68483f0e438c8332b477be11905bf557