### PR TITLE
Fix syntax in controller and adjust contact spec

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -46,7 +46,7 @@ class ArticlesController < ApplicationController
   def destroy
     @article.comments.destroy_all
     @article.destroy # Удаляем статью вместе с комментариями
-    redirect_to articles_path, t('flash.articles.deleted')
+    redirect_to articles_path, notice: t('flash.articles.deleted')
   end
 
   private
@@ -65,7 +65,7 @@ class ArticlesController < ApplicationController
 
     # Остальные действия доступны только автору
     if current_user != @article.user
-      redirect_to articles_path, alert: alert: t('flash.articles.unauthorized')
+      redirect_to articles_path, alert: t('flash.articles.unauthorized')
     end
   end
 end

--- a/spec/features/visitor_creates_contact_spec.rb
+++ b/spec/features/visitor_creates_contact_spec.rb
@@ -13,7 +13,7 @@ scenario "allows a guest to create contact" do
   fill_in :contact_email, with: 'exemp@mail.com'
   fill_in :contact_text, with: 'yooooooooooooooooooooooooo'
 
-  click_button 'Send'
+  click_button I18n.t('contacts.submit')
   expect(page).to have_content "Your message sent!"
 end
 end


### PR DESCRIPTION
## Summary
- fix typo in ArticlesController alert redirect
- show deletion notice when destroying article
- update contact feature spec to use i18n button text

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684846d63030833298fc1291e18c71ee