### PR TITLE
Implement user and admin task views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# Repository Guidelines
+
+## Testing
+Run the following commands before committing changes. These checks are not required to pass but should be run to show any issues:
+
+```
+bundle exec rubocop
+bundle exec rspec
+```
+
+## Branching
+Work directly on the main branch; do not create new branches.

--- a/app/controllers/admin/tasks_controller.rb
+++ b/app/controllers/admin/tasks_controller.rb
@@ -1,0 +1,14 @@
+class Admin::TasksController < ApplicationController
+  before_action :authenticate_user!
+  before_action :ensure_admin
+
+  def index
+    @articles = Article.includes(:assigned_user).order(created_at: :desc)
+  end
+
+  private
+
+  def ensure_admin
+    redirect_to(root_path, alert: t('flash.articles.unauthorized')) unless current_user&.admin?
+  end
+end

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -4,10 +4,17 @@ class ArticlesController < ApplicationController
   before_action :authenticate_user!, only: %i[new edit create update destroy]
   before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authorize_user, only: %i[edit update destroy]
+  before_action :authorize_view, only: :show
 
   # Список всех задач в обратном порядке создания
   def index
-    @articles = Article.order(created_at: :desc)
+    if current_user&.admin?
+      @articles = Article.includes(:assigned_user).order(created_at: :desc)
+    elsif current_user
+      @articles = Article.where('user_id = ? OR assigned_user_id = ?', current_user.id, current_user.id).order(created_at: :desc)
+    else
+      @articles = Article.none
+    end
   end
 
   # Показ отдельной статьи и комментариев к ней
@@ -67,5 +74,12 @@ class ArticlesController < ApplicationController
     if current_user != @article.user
       redirect_to articles_path, alert: t('flash.articles.unauthorized')
     end
+  end
+
+  def authorize_view
+    @article = Article.find(params[:id])
+    return if current_user&.admin? || @article.user_id == current_user&.id || @article.assigned_user_id == current_user&.id
+
+    redirect_to articles_path, alert: t('flash.articles.unauthorized')
   end
 end

--- a/app/views/admin/tasks/index.html.erb
+++ b/app/views/admin/tasks/index.html.erb
@@ -1,0 +1,19 @@
+<h1>Задачи по пользователям</h1>
+<table class="table">
+  <thead>
+    <tr>
+      <th>Название</th>
+      <th>Исполнитель</th>
+      <th>Статус</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @articles.each do |article| %>
+      <tr>
+        <td><%= link_to article.title, article %></td>
+        <td><%= article.assigned_user&.username || 'Не назначено' %></td>
+        <td><%= t("activerecord.attributes.article.status.#{article.status}") %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -38,6 +38,9 @@
             <li class="nav-item"><%= link_to "Поручения", articles_path, class: "nav-link" %></li>
             <li class="nav-item"><%= link_to "Новое поручение", new_article_path, class: "nav-link" %></li>
             <li class="nav-item"><%= link_to "Обратная связь", new_contacts_path, class: "nav-link" %></li>
+            <% if current_user&.admin? %>
+              <li class="nav-item"><%= link_to "Админ панель", admin_tasks_path, class: "nav-link" %></li>
+            <% end %>
             </ul>
 
             <ul class="navbar-nav ms-auto">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   resources :articles do
     resources :comments, only: [:create]
   end
+  namespace :admin do
+    resources :tasks, only: [:index]
+  end
   resource :contacts, only: [:create, :new]
   get 'terms' => "pages#terms"
   get 'about' => 'pages#about'

--- a/spec/features/admin_views_tasks_panel_spec.rb
+++ b/spec/features/admin_views_tasks_panel_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+feature 'Admin panel' do
+  before(:each) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+  end
+
+  scenario 'admin sees all tasks' do
+    admin = create(:user, role: 'admin', password: 'password123')
+    user = create(:user, password: 'password123')
+
+    create(:article, title: 'Admin Task 123', text: 'Some text 123', user: user, assigned_user: user)
+
+    visit new_user_session_path
+    fill_in 'Электронная почта', with: admin.email
+    fill_in 'Пароль', with: 'password123'
+    click_button 'Войти'
+
+    visit admin_tasks_path
+    expect(page).to have_content 'Admin Task'
+    expect(page).to have_content user.username
+  end
+end

--- a/spec/features/user_sees_only_own_articles_spec.rb
+++ b/spec/features/user_sees_only_own_articles_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+feature 'Article visibility' do
+  before(:each) do
+    DatabaseCleaner.strategy = :truncation
+    DatabaseCleaner.clean
+  end
+
+  scenario 'regular user sees only their own tasks' do
+    user = create(:user, password: 'password123')
+    other_user = create(:user, password: 'password123')
+
+    create(:article, title: 'User Task 123', text: 'Some text 123', user: user, assigned_user: user)
+    create(:article, title: 'Other Task 123', text: 'Other text 123', user: other_user, assigned_user: other_user)
+
+    visit new_user_session_path
+    fill_in 'Электронная почта', with: user.email
+    fill_in 'Пароль', with: 'password123'
+    click_button 'Войти'
+
+    visit articles_path
+    expect(page).to have_content 'User Task'
+    expect(page).not_to have_content 'Other Task'
+  end
+end


### PR DESCRIPTION
## Summary
- add root `AGENTS.md` with contribution rules
- filter articles by current user and add view authorization
- create admin panel to list tasks
- link admin panel in layout
- add request specs for user and admin task visibility

## Testing
- `RBENV_VERSION=3.3.8 bundle exec rubocop`
- `RBENV_VERSION=3.3.8 bundle exec rspec`


------
https://chatgpt.com/codex/tasks/task_e_6853eeb702948332a70458296ad65c82